### PR TITLE
feat: navegacion principal home turnos y perfil

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -5,32 +5,68 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 export default function LayoutTabs() {
   return (
-    <Tabs screenOptions={{ tabBarActiveTintColor: '#000' }}>
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveBackgroundColor: '#EDE9FE',
+        tabBarActiveTintColor: '#4C1D95',
+        tabBarInactiveTintColor: '#6B7280',
+        tabBarItemStyle: {
+          borderRadius: 18,
+          marginHorizontal: 6,
+          marginVertical: 8,
+        },
+        tabBarLabelStyle: {
+          fontSize: 13,
+          fontWeight: '700',
+          marginBottom: 4,
+        },
+        tabBarStyle: {
+          backgroundColor: '#FFF7ED',
+          borderTopColor: '#E5E7EB',
+          height: 72,
+          paddingHorizontal: 12,
+          paddingTop: 6,
+        },
+      }}
+    >
       <Tabs.Screen
         name="index"
         options={{
           title: 'Home',
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name="home-outline" size={size} color={color} />
+          tabBarIcon: ({ color, focused, size }) => (
+            <Ionicons name={focused ? 'home' : 'home-outline'} size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="turnos"
+        options={{
+          title: 'Turnos',
+          tabBarIcon: ({ color, focused, size }) => (
+            <MaterialIcons name={focused ? 'event' : 'event-note'} size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="perfil"
+        options={{
+          title: 'Perfil',
+          tabBarIcon: ({ color, focused, size }) => (
+            <MaterialIcons name={focused ? 'person' : 'person-outline'} size={size} color={color} />
           ),
         }}
       />
       <Tabs.Screen
         name="movies"
         options={{
-          title: 'Movies',
-          headerShown: false,
-          tabBarIcon: ({ color, size }) => <MaterialIcons name="movie" size={size} color={color} />,
+          href: null,
         }}
       />
       <Tabs.Screen
         name="categories"
         options={{
-          title: 'Categories',
-          headerShown: false,
-          tabBarIcon: ({ color, size }) => (
-            <MaterialIcons name="category" size={size} color={color} />
-          ),
+          href: null,
         }}
       />
     </Tabs>

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,26 +1,77 @@
-import React, { useEffect } from 'react';
-import { Button } from 'react-native';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import Screen from '@/components/ui/Screen';
-import { useRouter } from 'expo-router';
-import { getTurnos } from '@/services/turnos.service';
 
 export default function Home() {
-  const router = useRouter();
-
-  useEffect(() => {
-    // Aquí podrías cargar datos iniciales o realizar otras tareas de configuración
-    const getTurno = async (): Promise<any> => {
-      const data = await getTurnos();
-      console.log(data, 'esta es la data');
-    };
-
-    getTurno();
-  }, []);
-
   return (
     <Screen>
-      <Button title="Movies" onPress={() => router.push('/movies/index')} />
-      <Button title="Categories" />
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Dashboard</Text>
+          <Text style={styles.subtitle}>
+            Bienvenido a tu panel principal. Desde la navegacion inferior puedes acceder a turnos y
+            perfil.
+          </Text>
+        </View>
+
+        <View style={styles.summaryCard}>
+          <Text style={styles.sectionLabel}>Resumen rapido</Text>
+          <Text style={styles.summaryTitle}>Gestiona tu negocio desde un solo lugar</Text>
+          <Text style={styles.summaryText}>
+            Usa la barra inferior para navegar entre el dashboard, el listado de turnos y tu perfil.
+          </Text>
+        </View>
+      </View>
     </Screen>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 24,
+    justifyContent: 'center',
+  },
+  header: {
+    gap: 8,
+  },
+  title: {
+    color: '#0F172A',
+    fontSize: 30,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: '#475569',
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  summaryCard: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E2E8F0',
+    borderRadius: 24,
+    borderWidth: 1,
+    padding: 20,
+    shadowColor: '#0F172A',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+  },
+  sectionLabel: {
+    color: '#0EA5E9',
+    fontSize: 13,
+    fontWeight: '700',
+    marginBottom: 10,
+    textTransform: 'uppercase',
+  },
+  summaryTitle: {
+    color: '#0F172A',
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 10,
+  },
+  summaryText: {
+    color: '#64748B',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/src/app/(tabs)/perfil/_layout.tsx
+++ b/src/app/(tabs)/perfil/_layout.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function PerfilLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/src/app/(tabs)/perfil/index.tsx
+++ b/src/app/(tabs)/perfil/index.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Screen from '@/components/ui/Screen';
+
+const profileItems = [
+  { label: 'Emprendimiento', value: 'Studio Norte' },
+  { label: 'Rubro', value: 'Belleza y cuidado personal' },
+  { label: 'Telefono', value: '+54 9 11 5555 1234' },
+  { label: 'Email', value: 'contacto@studionorte.com' },
+];
+
+export default function PerfilScreen() {
+  return (
+    <Screen>
+      <View style={styles.container}>
+        <View style={styles.hero}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarText}>SN</Text>
+          </View>
+          <Text style={styles.title}>Mi Perfil</Text>
+          <Text style={styles.subtitle}>Gestiona la informacion principal de tu negocio.</Text>
+        </View>
+
+        <View style={styles.card}>
+          {profileItems.map((item) => (
+            <View key={item.label} style={styles.item}>
+              <Text style={styles.label}>{item.label}</Text>
+              <Text style={styles.value}>{item.value}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 24,
+  },
+  hero: {
+    alignItems: 'center',
+    gap: 10,
+    paddingTop: 12,
+  },
+  avatar: {
+    alignItems: 'center',
+    backgroundColor: '#0EA5E9',
+    borderRadius: 999,
+    height: 88,
+    justifyContent: 'center',
+    width: 88,
+  },
+  avatarText: {
+    color: '#FFFFFF',
+    fontSize: 28,
+    fontWeight: '800',
+  },
+  title: {
+    color: '#0F172A',
+    fontSize: 28,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: '#64748B',
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E2E8F0',
+    borderRadius: 20,
+    borderWidth: 1,
+    padding: 20,
+  },
+  item: {
+    borderBottomColor: '#E2E8F0',
+    borderBottomWidth: 1,
+    gap: 6,
+    paddingVertical: 14,
+  },
+  label: {
+    color: '#64748B',
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  value: {
+    color: '#0F172A',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/app/(tabs)/turnos/_layout.tsx
+++ b/src/app/(tabs)/turnos/_layout.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function TurnosLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/src/app/(tabs)/turnos/index.tsx
+++ b/src/app/(tabs)/turnos/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Screen from '@/components/ui/Screen';
+
+const upcomingAppointments = [
+  { id: '1', customer: 'Ana Perez', service: 'Corte de cabello', time: '09:00' },
+  { id: '2', customer: 'Lucas Gomez', service: 'Perfilado de barba', time: '11:30' },
+  { id: '3', customer: 'Micaela Diaz', service: 'Coloracion', time: '15:00' },
+];
+
+export default function TurnosScreen() {
+  return (
+    <Screen>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Listado de turnos</Text>
+          <Text style={styles.subtitle}>Consulta rapidamente las reservas del dia.</Text>
+        </View>
+
+        <View style={styles.list}>
+          {upcomingAppointments.map((turno) => (
+            <View key={turno.id} style={styles.card}>
+              <View style={styles.row}>
+                <Text style={styles.time}>{turno.time}</Text>
+                <Text style={styles.service}>{turno.service}</Text>
+              </View>
+              <Text style={styles.customer}>{turno.customer}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 24,
+  },
+  header: {
+    gap: 8,
+  },
+  title: {
+    color: '#0F172A',
+    fontSize: 28,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: '#64748B',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  list: {
+    gap: 12,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E2E8F0',
+    borderRadius: 18,
+    borderWidth: 1,
+    padding: 16,
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  time: {
+    color: '#0284C7',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  service: {
+    color: '#334155',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  customer: {
+    color: '#0F172A',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
## Resumen
Se implementa la navegacion principal de la app mediante una barra inferior con acceso a Home, Turnos y Perfil.

## Cambios realizados
- Se actualiza el layout de tabs principal
- Se reemplazan las tabs de ejemplo por Home, Turnos y Perfil
- Se agrega feedback visual para la pestaña activa
- Se crean las pantallas base de Turnos y Perfil
- Se ajusta Home para que funcione como Dashboard

## Criterios de aceptacion cubiertos
- Home visible y navega al Dashboard
- Turnos visible y navega al listado de turnos
- Perfil visible y navega a Mi Perfil
- Hay feedback visual al hacer click

## Notas
- Se mantuvieron ocultas las rutas de ejemplo del starter para no romper estructura existente
- Las pantallas de Turnos y Perfil quedaron preparadas como base para futuras integraciones
