### PR TITLE
Alinea la vista de turnos con el esquema actual de la base de datos

### DIFF
--- a/src/app/(tabs)/turnos/index.tsx
+++ b/src/app/(tabs)/turnos/index.tsx
@@ -1,33 +1,70 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Screen from '@/components/ui/Screen';
+import Card, { type TurnoCardData } from '@/components/ui/Card';
 
-const upcomingAppointments = [
-  { id: '1', customer: 'Ana Perez', service: 'Corte de cabello', time: '09:00' },
-  { id: '2', customer: 'Lucas Gomez', service: 'Perfilado de barba', time: '11:30' },
-  { id: '3', customer: 'Micaela Diaz', service: 'Coloracion', time: '15:00' },
+const upcomingAppointments: TurnoCardData[] = [
+  {
+    id: 1,
+    created_at: '2026-05-05T08:00:00.000Z',
+    duracion: '00:45:00',
+    estado: 'pendiente',
+    inicio: '2026-05-05T09:00:00.000Z',
+    precio: 18000,
+    cliente_id: 1,
+    emprendedor_id: 3,
+    fin: '2026-05-05T09:45:00.000Z',
+    update_at: '2026-05-05T08:00:00.000Z',
+    cliente: {
+      id: 1,
+      nombre: 'Ana Perez',
+    },
+  },
+  {
+    id: 2,
+    created_at: '2026-05-05T08:10:00.000Z',
+    duracion: '00:30:00',
+    estado: 'confirmado',
+    inicio: '2026-05-05T11:30:00.000Z',
+    precio: 12000,
+    cliente_id: 2,
+    emprendedor_id: 3,
+    fin: '2026-05-05T12:00:00.000Z',
+    update_at: '2026-05-05T08:10:00.000Z',
+    cliente: {
+      id: 2,
+      nombre: 'Lucas Gomez',
+    },
+  },
+  {
+    id: 3,
+    created_at: '2026-05-05T08:20:00.000Z',
+    duracion: '01:30:00',
+    estado: 'pendiente',
+    inicio: '2026-05-05T15:00:00.000Z',
+    precio: 32000,
+    cliente_id: 3,
+    emprendedor_id: 4,
+    fin: '2026-05-05T16:30:00.000Z',
+    update_at: '2026-05-05T08:20:00.000Z',
+    cliente: {
+      id: 3,
+      nombre: 'Micaela Diaz',
+    },
+  },
 ];
 
 export default function TurnosScreen() {
   return (
     <Screen>
-      <View style={styles.container}>
-        <View style={styles.header}>
-          <Text style={styles.title}>Listado de turnos</Text>
-          <Text style={styles.subtitle}>Consulta rapidamente las reservas del dia.</Text>
-        </View>
-
-        <View style={styles.list}>
-          {upcomingAppointments.map((turno) => (
-            <View key={turno.id} style={styles.card}>
-              <View style={styles.row}>
-                <Text style={styles.time}>{turno.time}</Text>
-                <Text style={styles.service}>{turno.service}</Text>
-              </View>
-              <Text style={styles.customer}>{turno.customer}</Text>
-            </View>
-          ))}
-        </View>
+      <View style={styles.list}>
+        {upcomingAppointments.length === 0 ? (
+          <Text style={styles.empty}>No hay turnos</Text>
+        ) : (
+          upcomingAppointments.map((turno) => (
+            <Card key={turno.id} turno={turno} />
+          ))
+        )}
       </View>
     </Screen>
   );
@@ -81,5 +118,11 @@ const styles = StyleSheet.create({
     color: '#0F172A',
     fontSize: 16,
     fontWeight: '600',
+  },
+  empty: {
+    textAlign: 'center',
+    color: '#64748B',
+    fontSize: 16,
+    marginTop: 20,
   },
 });

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+type ClienteResumen = {
+  id: number;
+  nombre: string;
+};
+
+export type TurnoCardData = {
+  id: number;
+  created_at: string;
+  duracion: string;
+  estado: string;
+  inicio: string;
+  precio: number;
+  cliente_id: number;
+  emprendedor_id: number;
+  fin: string;
+  update_at: string;
+  cliente?: ClienteResumen | null;
+};
+
+type Props = {
+  turno: TurnoCardData;
+  onPress?: (id: number) => void;
+};
+
+function formatDate(date: string) {
+  const parsedDate = new Date(date);
+
+  return parsedDate.toLocaleString('es-AR', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatPrice(price: number) {
+  return price.toLocaleString('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 0,
+  });
+}
+
+function Card({ turno, onPress }: Props) {
+  const isPressable = typeof onPress === 'function';
+  const customerName = turno.cliente?.nombre ?? `Cliente #${turno.cliente_id}`;
+
+  return (
+    <TouchableOpacity
+      activeOpacity={isPressable ? 0.8 : 1}
+      disabled={!isPressable}
+      onPress={() => onPress?.(turno.id)}
+      style={styles.card}
+    >
+      <View style={styles.iconContainer}>
+        <Ionicons name="calendar-outline" size={22} color="#0F172A" />
+      </View>
+
+      <View style={styles.info}>
+        <View style={styles.row}>
+          <Text style={styles.customer}>{customerName}</Text>
+          <Text style={styles.status}>{turno.estado}</Text>
+        </View>
+
+        <Text style={styles.time}>{formatDate(turno.inicio)}</Text>
+        <Text style={styles.meta}>
+          Duracion: {turno.duracion} · {formatPrice(turno.precio)}
+        </Text>
+      </View>
+
+      <Ionicons name="chevron-forward" size={20} color="#94A3B8" />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderColor: '#E2E8F0',
+    borderWidth: 1,
+    borderRadius: 18,
+    padding: 16,
+    gap: 12,
+  },
+  iconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: '#F1F5F9',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  info: {
+    flex: 1,
+    gap: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  customer: {
+    color: '#0F172A',
+    fontSize: 16,
+    fontWeight: '700',
+    flex: 1,
+  },
+  status: {
+    color: '#0284C7',
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'capitalize',
+  },
+  time: {
+    color: '#334155',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  meta: {
+    color: '#64748B',
+    fontSize: 12,
+  },
+});
+
+export default Card;

--- a/src/services/turnos.service.ts
+++ b/src/services/turnos.service.ts
@@ -1,8 +1,16 @@
 import { supabase } from '@/lib/supabase';
 
 export type Turno = {
-  id: string;
-  [key: string]: unknown;
+  id: number;
+  created_at: string;
+  duracion: string;
+  estado: string;
+  inicio: string;
+  precio: number;
+  cliente_id: number;
+  emprendedor_id: number;
+  fin: string;
+  update_at: string;
 };
 
 export type TurnoInput = Omit<Turno, 'id'>;
@@ -16,8 +24,8 @@ export async function getTurnos() {
   return (data ?? []) as Turno[];
 }
 
-export async function getTurnoById(id: string) {
-  const { data, error } = await supabase.from('turnos').select('*').eq('id', id).single();
+export async function getTurnoById(id: number) {
+  const { data, error } = await supabase.from('Turno').select('*').eq('id', id).single();
 
   if (error) {
     throw new Error(error.message);
@@ -28,7 +36,7 @@ export async function getTurnoById(id: string) {
 
 export async function createTurno(data: TurnoInput) {
   const { data: createdTurno, error } = await supabase
-    .from('turnos')
+    .from('Turno')
     .insert(data)
     .select('*')
     .single();
@@ -40,9 +48,9 @@ export async function createTurno(data: TurnoInput) {
   return createdTurno as Turno;
 }
 
-export async function updateTurno(id: string, data: Partial<TurnoInput>) {
+export async function updateTurno(id: number, data: Partial<TurnoInput>) {
   const { data: updatedTurno, error } = await supabase
-    .from('turnos')
+    .from('Turno')
     .update(data)
     .eq('id', id)
     .select('*')
@@ -55,8 +63,8 @@ export async function updateTurno(id: string, data: Partial<TurnoInput>) {
   return updatedTurno as Turno;
 }
 
-export async function deleteTurno(id: string) {
-  const { error } = await supabase.from('turnos').delete().eq('id', id);
+export async function deleteTurno(id: number) {
+  const { error } = await supabase.from('Turno').delete().eq('id', id);
 
   if (error) {
     throw new Error(error.message);


### PR DESCRIPTION
Este PR adapta la implementación de turnos al esquema actual de la tabla Turno.

Cambios incluidos:

se refactorizó Card para recibir un objeto turno con campos reales del modelo
se actualizó el mock de turnos/index.tsx para reflejar la estructura actual de la base
se tipó turnos.service.ts con los campos correspondientes
se unificó el acceso a la tabla Turno en Supabase
se corrigió el tipo de id para manejarlo como number